### PR TITLE
cache-dir fix

### DIFF
--- a/rasa_nlu_examples/errors.py
+++ b/rasa_nlu_examples/errors.py
@@ -1,0 +1,2 @@
+class RasaFileNotFound(Exception):
+    pass

--- a/rasa_nlu_examples/featurizers/dense/bpemb_featurizer.py
+++ b/rasa_nlu_examples/featurizers/dense/bpemb_featurizer.py
@@ -44,7 +44,7 @@ class BytePairFeaturizer(DenseFeaturizer):
         # model, the closest size is chosen
         "vs_fallback": True,
         # specifies the folder in which downloaded BPEmb files will be cached
-        "cache_dir": Path.home() / Path(".cache/bpemb"),
+        "cache_dir": str(Path.home() / Path(".cache/bpemb")),
         # specifies the path to a custom SentencePiece model file
         "model_file": None,
         # specifies the path to a custom embedding file. Supported formats are Word2Vec

--- a/tests/test_cli/test_commandline.py
+++ b/tests/test_cli/test_commandline.py
@@ -1,12 +1,12 @@
 import subprocess
-
 import pytest
 
 
-@pytest.mark.parametrize(
-    "fp", ["fasttext-config.yml", "printer-config.yml", "bytepair-config.yml"]
-)
-def test_run_train_command(fp):
+yml_files = ["fasttext-config.yml", "printer-config.yml", "bytepair-config.yml"]
+
+
+@pytest.mark.parametrize("fp", yml_files)
+def test_run_test_command(fp):
     cmd = [
         "rasa",
         "test",
@@ -20,6 +20,21 @@ def test_run_train_command(fp):
         "1",
         "--folds",
         "2",
+    ]
+    status = subprocess.run(cmd)
+    assert status.returncode == 0
+
+
+@pytest.mark.parametrize("fp", yml_files)
+def test_run_train_command(fp):
+    cmd = [
+        "rasa",
+        "train",
+        "nlu",
+        "-u",
+        "tests/data/nlu.md",
+        "--config",
+        f"tests/configs/{fp}",
     ]
     status = subprocess.run(cmd)
     assert status.returncode == 0


### PR DESCRIPTION
The cache dir for bpemb is now a string instead of a path. This should make it json serializable.