### PR TITLE
Remove language specification from pre-commit config, and adjust flake8 config to ignore W503 and E203 for flake8/black compatibility

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,4 +2,4 @@
 max-complexity=10
 max-line-length=125
 exclude = */__init__.py, */*/__init__.py, venv
-ignore=E722
+ignore=E722,E203,W503

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,4 +16,3 @@ repos:
     rev: stable
     hooks:
       - id: black
-        language_version: python3.6


### PR DESCRIPTION
See title. I figured this should go into its own PR, rather than polluting another. 

I didn't adjust the `max-line-length` to 88, because this would render quite a few files failing, but if you'd like I'm happy to change this to 88 and fix the failing files.