### PR TITLE
Stopword Remover

### DIFF
--- a/docs/docs/meta/stopwords.md
+++ b/docs/docs/meta/stopwords.md
@@ -1,0 +1,29 @@
+This component can remove stopwords from the text. The idea is to filter
+out words before the text is passed to the tokeniser. This way we prevent
+many alignment mishaps between the tokens en the found entities.
+
+## Configurable Variables
+
+- **path**: path to a file that contains a stopword on each line
+
+## Base Usage
+
+Here's an example configuration.
+
+```yaml
+language: en
+
+pipeline:
+- name: rasa_nlu_examples.meta.StopWordRemover
+  path: tests/data/stopwords/stopwords.txt
+- name: WhitespaceTokenizer
+- name: LexicalSyntacticFeaturizer
+- name: CountVectorsFeaturizer
+  analyzer: char_wb
+  min_ngram: 1
+  max_ngram: 4
+- name: DIETClassifier
+  epochs: 100
+```
+
+Note that you *must* place the `StopWordRemover` component before the tokeniser.

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,10 +88,10 @@ entities.  We provide some examples of alternative intent classifiers here.
 
 ## **Meta**
 
-The components listed here won't effect the NLU pipeline but they might instead cause extra logs
-to appear to help with debugging.
+The components listed here are useful, but fall in the "other" category.
 
 - **`rasa_nlu_examples.meta.Printer` [docs](docs/meta/printer/)**
+- **`rasa_nlu_examples.meta.StopWordsRemover` [docs](docs/meta/stopwords/)**
 - **`rasa_nlu_examples.scikit.RasaClassifier` [docs](docs/jupyter/tools/#rasa_nlu_examples.scikit.classifier.RasaClassifier)**
 - **`rasa_nlu_examples.scikit.dataframe_to_nlu_file` [docs](docs/jupyter/tools/#rasa_nlu_examples.scikit.common.dataframe_to_nlu_file)**
 - **`rasa_nlu_examples.scikit.nlu_path_to_dataframe` [docs](docs/jupyter/tools/#rasa_nlu_examples.scikit.common.nlu_path_to_dataframe)**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
           - ThaiTokenizer: docs/tokenizer/thai_tokenizer.md
       - Meta:
         - Printer: docs/meta/printer.md
+        - StopWordsRemover: docs/meta/stopwords.md
       - Featurizers:
         - GensimFeaturizer: docs/featurizer/gensim.md
         - FastTextFeaturizer: docs/featurizer/fasttext.md

--- a/rasa_nlu_examples/meta/__init__.py
+++ b/rasa_nlu_examples/meta/__init__.py
@@ -1,3 +1,4 @@
 from .printer import Printer
+from .stopwordremover import StopWordRemover
 
-__all__ = ["Printer"]
+__all__ = ["Printer", "StopWordRemover"]

--- a/rasa_nlu_examples/meta/stopwordremover.py
+++ b/rasa_nlu_examples/meta/stopwordremover.py
@@ -1,0 +1,72 @@
+import typing
+import pathlib
+from typing import Any, Optional, Text, Dict, List, Type
+
+from flashtext import KeywordProcessor
+from rasa.nlu.components import Component
+from rasa.shared.nlu.constants import TEXT
+from rasa.nlu.config import RasaNLUModelConfig
+from rasa.shared.nlu.training_data.message import Message
+from rasa.shared.nlu.training_data.training_data import TrainingData
+
+
+if typing.TYPE_CHECKING:
+    from rasa.nlu.model import Metadata
+
+
+class StopWordRemover(Component):
+    """
+    Removes text from the message before it is passed to the tokenizer.
+    """
+
+    @classmethod
+    def required_components(cls) -> List[Type[Component]]:
+        return []
+
+    defaults = {"alias": None}
+    language_list = None
+
+    def __init__(self, component_config: Optional[Dict[Text, Any]] = None) -> None:
+        super().__init__(component_config)
+
+        if not self.component_config["path"]:
+            raise ValueError(
+                "You must specify the `path` parameter for StopWordRemover in `config.yml`."
+            )
+
+        self.stopwords = (
+            pathlib.Path(self.component_config["path"]).read_text().split("\n")
+        )
+        self.keyword_processor = KeywordProcessor(case_sensitive=False)
+        for word in self.stopwords:
+            self.keyword_processor.add_keyword(word, "")
+
+    def train(
+        self,
+        training_data: TrainingData,
+        config: Optional[RasaNLUModelConfig] = None,
+        **kwargs: Any,
+    ) -> None:
+        pass
+
+    def process(self, message: Message, **kwargs: Any) -> None:
+        message.set(TEXT, self.keyword_processor.replace_keywords(message.get(TEXT)))
+
+    def persist(self, file_name: Text, model_dir: Text) -> Optional[Dict[Text, Any]]:
+        pass
+
+    @classmethod
+    def load(
+        cls,
+        meta: Dict[Text, Any],
+        model_dir: Optional[Text] = None,
+        model_metadata: Optional["Metadata"] = None,
+        cached_component: Optional["Component"] = None,
+        **kwargs: Any,
+    ) -> "Component":
+        """Load this component from file."""
+
+        if cached_component:
+            return cached_component
+
+        return cls(meta)

--- a/rasa_nlu_examples/meta/stopwordremover.py
+++ b/rasa_nlu_examples/meta/stopwordremover.py
@@ -39,7 +39,7 @@ class StopWordRemover(Component):
         )
         self.keyword_processor = KeywordProcessor(case_sensitive=False)
         for word in self.stopwords:
-            self.keyword_processor.add_keyword(word, "")
+            self.keyword_processor.add_keyword(word)
 
     def train(
         self,
@@ -50,7 +50,11 @@ class StopWordRemover(Component):
         pass
 
     def process(self, message: Message, **kwargs: Any) -> None:
-        message.set(TEXT, self.keyword_processor.replace_keywords(message.get(TEXT)))
+        txt = message.get(TEXT)
+        found_words = self.keyword_processor.extract_keywords(message.get(TEXT))
+        for word in found_words:
+            txt = txt.replace(word, "")
+        message.set(TEXT, txt.strip())
 
     def persist(self, file_name: Text, model_dir: Text) -> Optional[Dict[Text, Any]]:
         pass

--- a/readme.md
+++ b/readme.md
@@ -130,12 +130,12 @@ entities.  We provide some examples of alternative intent classifiers here.
 
 - **`rasa_nlu_examples.fallback.FasttextLanguageFallbackClassifier` [docs](https://rasahq.github.io/rasa-nlu-examples/docs/fallback/fasttextlanguagefallback.md)**
 
-## **Meta**
+## **Other**
 
-The components listed here won't effect the NLU pipeline but they might instead cause extra logs
-to appear to help with debugging.
+The components listed here are useful, but fall in the "other" category.
 
 - **`rasa_nlu_examples.meta.Printer` [docs](https://rasahq.github.io/rasa-nlu-examples/docs/meta/printer/)**
+- **`rasa_nlu_examples.meta.StopWordsRemover` [docs](docs/meta/stopwords/)**
 - **`rasa_nlu_examples.scikit.RasaClassifier` [docs](https://rasahq.github.io/rasa-nlu-examples/docs/jupyter/tools/#rasa_nlu_examples.scikit.classifier.RasaClassifier)**
 - **`rasa_nlu_examples.scikit.dataframe_to_nlu_file` [docs](https://rasahq.github.io/rasa-nlu-examples/docs/jupyter/tools/#rasa_nlu_examples.scikit.common.dataframe_to_nlu_file)**
 - **`rasa_nlu_examples.scikit.nlu_path_to_dataframe` [docs](https://rasahq.github.io/rasa-nlu-examples/docs/jupyter/tools/#rasa_nlu_examples.scikit.common.nlu_path_to_dataframe)**

--- a/tests/configs/stopword-config.yml
+++ b/tests/configs/stopword-config.yml
@@ -1,0 +1,13 @@
+language: en
+
+pipeline:
+- name: rasa_nlu_examples.meta.StopWordRemover
+  path: tests/data/stopwords/stopwords.txt
+- name: WhitespaceTokenizer
+- name: LexicalSyntacticFeaturizer
+- name: CountVectorsFeaturizer
+  analyzer: char_wb
+  min_ngram: 1
+  max_ngram: 4
+- name: DIETClassifier
+  epochs: 1

--- a/tests/data/stopwords/stopwords.txt
+++ b/tests/data/stopwords/stopwords.txt
@@ -1,0 +1,3 @@
+stopword
+stop
+word

--- a/tests/test_meta/test_stop_string_remover.py
+++ b/tests/test_meta/test_stop_string_remover.py
@@ -6,7 +6,9 @@ from rasa.shared.nlu.training_data.message import Message
 
 remover = StopWordRemover(
     component_config={
-        "path": pathlib.Path.cwd() / "tests" / "data" / "stopwords" / "stopwords.txt"
+        "path": str(
+            pathlib.Path.cwd() / "tests" / "data" / "stopwords" / "stopwords.txt"
+        )
     }
 )
 checks = [

--- a/tests/test_meta/test_stop_string_remover.py
+++ b/tests/test_meta/test_stop_string_remover.py
@@ -13,12 +13,13 @@ checks = [
     ("", ""),
     ("this is a stopword", "this is a"),
     ("stop that word", "that"),
-    ("words", "s"),
+    ("words", "words"),
 ]
 
 
 @pytest.mark.parametrize("goes_in, goes_out", checks)
 def test_leaves_empty_msg_alone(goes_in, goes_out):
-    message = Message(text="")
+    message = Message(text=goes_in)
     remover.process(message)
-    assert message.get("text") == ""
+    print(remover.stopwords)
+    assert message.get("text") == goes_out

--- a/tests/test_meta/test_stopwordremover.py
+++ b/tests/test_meta/test_stopwordremover.py
@@ -1,0 +1,24 @@
+import pytest
+import pathlib
+from rasa_nlu_examples.meta import StopWordRemover
+from rasa.shared.nlu.training_data.message import Message
+
+
+remover = StopWordRemover(
+    component_config={
+        "path": pathlib.Path.cwd() / "tests" / "data" / "stopwords" / "stopwords.txt"
+    }
+)
+checks = [
+    ("", ""),
+    ("this is a stopword", "this is a"),
+    ("stop that word", "that"),
+    ("words", "s"),
+]
+
+
+@pytest.mark.parametrize("goes_in, goes_out", checks)
+def test_leaves_empty_msg_alone(goes_in, goes_out):
+    message = Message(text="")
+    remover.process(message)
+    assert message.get("text") == ""

--- a/tests/test_smoke/test_english.py
+++ b/tests/test_smoke/test_english.py
@@ -9,6 +9,7 @@ from rasa.model_testing import test_nlu as run_nlu
 english_yml_files = [
     "printer-config.yml",
     "fasttext-config.yml",
+    "stopword-config.yml",
     "bytepair-config.yml",
     "gensim-config.yml",
     "dateparser-config.yml",


### PR DESCRIPTION
It's a hacky implementation but we're removing substrings from the text. We could also remove tokens, but this would have all sorts of nasty consequences when we also consider entities.

I should rename the implementation to `StopStringRemover`. 